### PR TITLE
support for DSM 7, support for the FRITZ! Lab beta version 7.39

### DIFF
--- a/FritzLog.php
+++ b/FritzLog.php
@@ -25,7 +25,7 @@ class FritzLog
 		return $this->_offset = $value;
 	}
 	
-	public function add(DateTime $ts, int $category, int $id, string $message)
+	public function add(DateTime $ts, string $category, int $id, string $message)
 	{
 		array_push($this->Log, new FritzLogEvent($this, $ts, $category, $id, $message));
 	}

--- a/FritzLogEvent.php
+++ b/FritzLogEvent.php
@@ -8,10 +8,28 @@ class FritzLogEvent implements SysLogEvent
 	private $_dt;
 	private $_parent;
 	
-	public function __construct(FritzLog $parent, DateTime $ts, int $category, int $id, string $message)
+	public function __construct(FritzLog $parent, DateTime $ts, string $category, int $id, string $message)
 	{
 		$this->_ts = $ts->getTimeStamp();
-		$this->_category = $category;
+              if (is_numeric($category))
+		{
+			$this->_category = (int)$category;
+		}
+		else
+		{
+			switch($category)
+			{
+				case 'sys': $this->_category = 1; break;
+    				case 'net': $this->_category = 2; break;
+    				case 'fon': $this->_category = 3; break;
+    				case 'wlan': $this->_category = 4; break;
+    				case 'usb': $this->_category = 5; break;
+   			 	
+				default:
+       			$this->_category = 0;
+       		 	break;
+			}
+		}
 		$this->_id = $id;
 		$this->_message = $message;
 		$this->_parent = $parent;

--- a/FritzLuaLog.php
+++ b/FritzLuaLog.php
@@ -7,6 +7,8 @@ class FritzLuaLog extends FritzLuaSession
 	
 	public function parselogs(object $json, string $ignore) : FritzLog
 	{
+		global $logVersion;
+
 		$result = new FritzLog(date_default_timezone_get());
 		
 		if($this->debug)print_r('JSON result =' . var_dump($json));

--- a/FritzLuaLog.php
+++ b/FritzLuaLog.php
@@ -12,23 +12,28 @@ class FritzLuaLog extends FritzLuaSession
 		if($this->debug)print_r('JSON result =' . var_dump($json));
 		foreach($json->data->log as $row)
 		{
-			$first=$first+1;
-			$datetime= str_replace('.','-',substr($row[0],0,6).'20'.substr($row[0],-2)) . ' ' . $row[1] . '.000'; // this will be bad in 2099, idc tbh
+			$fieldDate     = ($logVersion==0) ? ($row[0]) : ($row->date);
+			$fieldTime     = ($logVersion==0) ? ($row[1]) : ($row->time);
+			$fieldMessage  = ($logVersion==0) ? ($row[2]) : ($row->msg);
+			$fieldId       = ($logVersion==0) ? ($row[3]) : ($row->id);
+			$fieldCategory = ($logVersion==0) ? ($row[4]) : ($row->group);
+
+			$datetime= str_replace('.','-',substr($fieldDate,0,6).'20'.substr($fieldDate,-2)) . ' ' . $fieldTime . '.000'; // this will be bad in 2099, idc tbh
 			$dt = new DateTime($datetime, new DateTimeZone(date_default_timezone_get()));			
 			if (strlen($ignore)>0)
 			{  
-				if(str_starts_with($row[2], $ignore) || str_starts_with($datetime, '2070-'))
+				if(str_starts_with($fieldMessage, $ignore) || str_starts_with($datetime, '2070-'))
 				{
 					;
 				}
 				else
 				{
-					$result->add($dt,(int)$row[4],(int)$row[3], $row[2]);
+					$result->add($dt, $fieldCategory, (int)$fieldId, $fieldMessage);
 				}
 			}
 			else
 			{
-				$result->add($dt,(int)$row[4],(int)$row[3], $row[2]); 
+				$result->add($dt, $fieldCategory, (int)$fieldId, $fieldMessage); 
 			}
 		
 		}		

--- a/FritzLuaSession.php
+++ b/FritzLuaSession.php
@@ -99,7 +99,6 @@ class FritzLuaSession
 		
 		// Receive server response ...
 		curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
-		$first=0;
 		$response = curl_exec($this->ch);
 		if ($parseJson===true)
 		{

--- a/FritzLuaSession.php
+++ b/FritzLuaSession.php
@@ -103,6 +103,7 @@ class FritzLuaSession
 		$response = curl_exec($this->ch);
 		if ($parseJson===true)
 		{
+			file_put_contents("response.json",$response);
 			$json = json_decode($response);
 			if ($this->sid===$json->sid)
 			{

--- a/FritzLuaSession.php
+++ b/FritzLuaSession.php
@@ -103,7 +103,6 @@ class FritzLuaSession
 		$response = curl_exec($this->ch);
 		if ($parseJson===true)
 		{
-			file_put_contents("response.json",$response);
 			$json = json_decode($response);
 			if ($this->sid===$json->sid)
 			{

--- a/LogCenter.php
+++ b/LogCenter.php
@@ -7,7 +7,7 @@ function getLogCenterTail(string $path, string $host, int $limit=400, int $fritz
 	$valsw=0;
 	
 	$dbh = getLogCenterDb($path, $host);
-	$query =  "select * FROM logs order by utcsec desc, id desc limit " . $fritz_limit;
+	$query =  "select * FROM logs".((6==$dsm)?(""):(" where host='".$host."'"))." order by utcsec desc, id desc limit " . $fritz_limit;
 	//echo($query . PHP_EOL);
 	
 	$rows = $dbh->query($query);
@@ -37,7 +37,7 @@ function getLogCenterTail(string $path, string $host, int $limit=400, int $fritz
 			}
 		}
 		
-		$query =  "select * FROM logs where utcsec>=" .$prev_ts ." order by utcsec desc, id desc limit " . $fritz_limit;
+		$query =  "select * FROM logs where utcsec>=" .$prev_ts .((6==$dsm)?(""):(" and host='".$host."'"))." order by utcsec desc, id desc limit " . $fritz_limit;
 		//echo($query . PHP_EOL);
 		$rows = $dbh->query($query);
 		$rows = $rows->fetchall();		
@@ -62,8 +62,9 @@ function getLogCenterTimeStamps(string $path, string $host, int $limit=10)
 	$valsw=0;
 	
 	$dbh = getLogCenterDb($path, $host);
-	$query =  "select * FROM logs order by utcsec desc, id desc limit 399";
-	
+	$query =  "select * FROM logs".((6==$dsm)?(""):(" where host='".$host."'"))." order by utcsec desc, id desc limit 399";
+	//echo($query . PHP_EOL);
+
 	$rows = $dbh->query($query);
 	if($rows===false)
 	{
@@ -104,8 +105,8 @@ function getLogCenterDb(string $path, string $host)
 			    PDO::ATTR_EMULATE_PREPARES   => false,
 	];
 
-	$dir = 'sqlite:'.$path.$host.'/SYNOSYSLOGDB_'.$host.'.DB';
-	
+	$dir = (6 == $dsm) ? 'sqlite:'.$path.$host.'/SYNOSYSLOGDB_'.$host.'.DB' : 'sqlite:'.$path.'/SYNOSYSLOGDB_pb_ARCH.DB';
+	//echo $dir . PHP_EOL;
 	try
 	{
 		$pdo  = new PDO($dir);
@@ -132,7 +133,7 @@ function getLogCenterCount(string $path, string $host, int $limit=400, int $frit
 	$valsw=0;
 	
 	$dbh = getLogCenterDb($path, $host);
-	$query =  "select * FROM logs order by utcsec desc, id desc limit " . $fritz_limit;
+	$query =  "select * FROM logs".((6==$dsm)?(""):(" where host='".$host."'"))." order by utcsec desc, id desc limit " . $fritz_limit;
 	//echo($query . PHP_EOL);
 	
 	$rows = $dbh->query($query);

--- a/LogCenter.php
+++ b/LogCenter.php
@@ -1,6 +1,8 @@
 <?
 function getLogCenterTail(string $path, string $host, int $limit=400, int $fritz_limit=400)
 {
+	global $dsm;
+	
 	$last_ts = array();
 	$tail = array();
 	$prev_ts=0;
@@ -56,7 +58,9 @@ function getLogCenterTail(string $path, string $host, int $limit=400, int $fritz
 
 
 function getLogCenterTimeStamps(string $path, string $host, int $limit=10)
-{
+{	
+	global $dsm;
+
 	$last_ts = array();
 	$prev_ts=0;
 	$valsw=0;
@@ -99,13 +103,15 @@ function getLogCenterTimeStamps(string $path, string $host, int $limit=10)
 
 function getLogCenterDb(string $path, string $host)
 {
+	global $dsm;
+
 	$options = [
 			    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
 			    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
 			    PDO::ATTR_EMULATE_PREPARES   => false,
 	];
 
-	$dir = (6 == $dsm) ? 'sqlite:'.$path.$host.'/SYNOSYSLOGDB_'.$host.'.DB' : 'sqlite:'.$path.'/SYNOSYSLOGDB_pb_ARCH.DB';
+	$dir = (6 == $dsm) ? 'sqlite:'.$path.'/'.$host.'/SYNOSYSLOGDB_'.$host.'.DB' : 'sqlite:'.$path.'/SYNOSYSLOGDB__ARCH.DB';
 	//echo $dir . PHP_EOL;
 	try
 	{
@@ -127,6 +133,8 @@ function removeDbInitMarker(string $path, string $host)
 }
 function getLogCenterCount(string $path, string $host, int $limit=400, int $fritz_limit=400)
 {
+	global $dsm;
+
 	$last_ts = array();
 	$tail = array();
 	$prev_ts=0;

--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ Update May 1, 2020: I noticed that the duplicate timestamps were no longer appea
 Before you can run the script, please review the changes you need to make to your [modem](https://github.com/biocoder-frodo/FRITZBox-SynologyLogCenterDaemon/wiki/Settings-on-your-FRITZ!Box) and your [NAS](https://github.com/biocoder-frodo/FRITZBox-SynologyLogCenterDaemon/wiki/Settings-on-your-Synology-NAS)
 
 The script has the following command line options:
-* -l Absolute path to the Log Center databases folder
-* -p Optional, absolute path to a textfile that contains the FRITZ!Box password, defaults to ./(username).pwdfile when omitted
-* -k Optional, absolute path to certificate file of your FRITZ!Box, defaults to ./boxcert.cer when omitted
-* -t Optional, http or https, defaults to https when omitted
+* -l Absolute path to the Log Center databases folder.
+* -p Optional, absolute path to a textfile that contains the FRITZ!Box password, defaults to ./(username).pwdfile when omitted.
+* -k Optional, absolute path to certificate file of your FRITZ!Box, defaults to ./boxcert.cer when omitted.
+* -t Optional, http or https, defaults to https when omitted.
 * -f Optional, the name of your FRITZ!Box, other than fritz.box
 * -r Optional, the name of your FRITZ!Repeater, this login only uses the password for the admin interface of your repeater.
-* -u Optional, the name of your FRITZ!Box user, other than stats
-* -q Optional, fetch the eventlog once and dump it to the console
-* -d Optional, test the database connection and dump a rowcount to the console
-* -i Optonal, initialises the Synology SQLite database. Logcenter has to be running and configured to listen to the port you specify.
-* --udp Optional, the UDP port to contact Log Center on. The default port is 516
+* -u Optional, the name of your FRITZ!Box user, other than stats.
+* -q Optional, fetch the eventlog once and dump it to the console.
+* -d Optional, test the database connection and dump a rowcount to the console.
+* -i Optional, initialises the Synology SQLite database. Logcenter has to be running and configured to listen to the port you specify.
+* --udp Optional, the UDP port to contact Log Center on. The default port is 516.
+* -a Optional, it appears that on DSM7 the source host is no longer in the filename of the Logcenter database. Use this option if you are on DSM 7.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ The script has the following command line options:
 * -i Optional, initialises the Synology SQLite database. Logcenter has to be running and configured to listen to the port you specify.
 * --udp Optional, the UDP port to contact Log Center on. The default port is 516.
 * -a Optional, it appears that on DSM7 the source host is no longer in the filename of the Logcenter database. Use this option if you are on DSM 7.
+* -j Optional, newer FRITZ!OS versions return a changed JSON response. Use this if you get the "Uncaught Error: Cannot use object of type stdClass as array in FritzLuaLog.php", while testing the -q option.
+

--- a/fritzbox-syslog-daemon.php
+++ b/fritzbox-syslog-daemon.php
@@ -9,17 +9,22 @@ include_once 'UdpLog.php';
 global $dsm;
 $dsm=6;
 
+global $logVersion;
+$logVersion=0;
+
 $logcenter_path = '/var/services/homes/admin/logs/'; // Your logs are located on the volume you installed the Log Center package on.
 $syslog_port = 516; // my default port is 516
 
 //parse the commandline to get the connectiondetails for your Fritz!Box, the default username is 'stats'.
-$options = parseCommandLine('idql:', array("udp::","ignore::"), 'stats');
+$options = parseCommandLine('idqjl:', array("udp::","ignore::"), 'stats');
 echo 'pid =' . getmypid() . PHP_EOL;
 var_dump($options);
 	
 $rundbquery = cmdLineSwitch("d",$options);
 $runquery = cmdLineSwitch("q",$options);
 $initDb = cmdLineSwitch("i",$options);
+
+if (cmdLineSwitch("j",$options)==TRUE) $logVersion=1;
 
 $anonymousDb = cmdLineSwitch("a",$options);
 if ($anonymousDb===TRUE) $dsm=7;

--- a/fritzbox-syslog-daemon.php
+++ b/fritzbox-syslog-daemon.php
@@ -6,6 +6,8 @@ include_once 'FritzLuaLog.php';
 include_once 'LogCenter.php';
 include_once 'UdpLog.php';
 
+global $dsm;
+$dsm=6;
 
 $logcenter_path = '/var/services/homes/admin/logs/'; // Your logs are located on the volume you installed the Log Center package on.
 $syslog_port = 516; // my default port is 516
@@ -18,6 +20,9 @@ var_dump($options);
 $rundbquery = cmdLineSwitch("d",$options);
 $runquery = cmdLineSwitch("q",$options);
 $initDb = cmdLineSwitch("i",$options);
+
+$anonymousDb = cmdLineSwitch("a",$options);
+if ($anonymousDb===TRUE) $dsm=7;
 
 $filter="";
 if(array_key_exists("ignore",$options)) $filter = $options["ignore"];

--- a/fritzbox-syslog-daemon.php
+++ b/fritzbox-syslog-daemon.php
@@ -9,7 +9,6 @@ include_once 'UdpLog.php';
 global $dsm;
 $dsm=6;
 
-global $logVersion;
 $logVersion=0;
 
 $logcenter_path = '/var/services/homes/admin/logs/'; // Your logs are located on the volume you installed the Log Center package on.


### PR DESCRIPTION
The FRITZ! Lab (version 7.39) is available for:

    FRITZ!Box 7590 AX, 7590, 7530 AX, 7530 (29 September 2022) 
    FRITZ!Box 6690, 6660, 6591 Cable (29 September 2022)
    FRITZ!Box 6850 5G, 6850 LTE (19 September 2022)
    FRITZ!Repeater 3000, 2400 (23 September 2022)
    FRITZ!Box 6890 LTE (15 July 2022)
